### PR TITLE
Fix startup error : java.lang.NullPointerException when storing badge

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/badge/impl/BadgeRegistryImpl.java
@@ -8,6 +8,7 @@ import org.exoplatform.addons.gamification.service.setting.badge.BadgeRegistry;
 import org.exoplatform.addons.gamification.service.setting.badge.model.BadgeConfig;
 import org.exoplatform.commons.file.model.FileItem;
 import org.exoplatform.commons.file.services.FileService;
+import org.exoplatform.commons.file.services.NameSpaceService;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
@@ -29,10 +30,8 @@ public class BadgeRegistryImpl implements Startable, BadgeRegistry {
     private FileService fileService;
     private DomainService domainService;
 
-    public BadgeRegistryImpl(FileService fileService) {
-
+    public BadgeRegistryImpl(FileService fileService, NameSpaceService nameSpaceService) {
         this.badgesMap = new HashMap<String, BadgeConfig>();
-
         this.fileService = fileService;
     }
 


### PR DESCRIPTION
java.lang.NullPointerException when storing badge image because the Fileservice namespace is not yet stored.
The fix adds NamespaceService for the constructor of BadgeRegistryImpl to make sure that the latter won't start until NamespaceService stores all the badge images