### PR TITLE
PLF-8656 : Errors at startup about already existing gamification rules

### DIFF
--- a/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/service/setting/rule/impl/RuleRegistryImpl.java
@@ -95,7 +95,7 @@ public class RuleRegistryImpl implements Startable, RuleRegistry {
                 CommonsUtils.getService(RuleService.class).updateRule(ruleDTO);
             }else{
                 RuleDTO ruleDto = new RuleDTO();
-                ruleDto.setTitle("GAMIFICATION_DEFAULT_DATA_PREFIX"+ruleConfig.getTitle());
+                ruleDto.setTitle(GAMIFICATION_DEFAULT_DATA_PREFIX+ruleConfig.getTitle());
                 ruleDto.setScore(ruleConfig.getScore());
                 ruleDto.setEnabled(ruleConfig.isEnable());
                 ruleDto.setEvent(ruleConfig.getEvent());


### PR DESCRIPTION
On PLF 5.3.0, at second start, the gamification addon throws errors about rules existing when trying to store rules
In fact, the GAMIFICATION_DEFAULT_DATA_PREFIX used in rules names is used as string when checking if the rule exists

This change address the issue by correctly using the property instead of the string name of the property