### PR TITLE
Fix/PLF-8656

### DIFF
--- a/extension/src/main/webapp/WEB-INF/conf/configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/configuration.xml
@@ -43,6 +43,7 @@
     <import>war:/conf/gamification/listener/domain-listener-configuration.xml</import>
     <import>war:/conf/gamification/listener/user-listeners-configuration.xml</import>
     <import>war:/conf/gamification/bundle/bundle-configuration.xml</import>
+    <import>war:/conf/gamification/upgrade/upgrade-configuration.xml</import>
     <!--<import>war:/conf/gamification/wcm/deployment/gamification-deployment-comnfiguration.xml</import>-->
 
 </configuration>

--- a/extension/src/main/webapp/WEB-INF/conf/gamification/upgrade/upgrade-configuration.xml
+++ b/extension/src/main/webapp/WEB-INF/conf/gamification/upgrade/upgrade-configuration.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<configuration
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd http://www.exoplatform.org/xml/ns/kernel_1_2.xsd"
+        xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
+        
+    <external-component-plugins>
+        <target-component>org.exoplatform.commons.upgrade.UpgradeProductService</target-component>
+        <component-plugin>
+            <name>RuleNameUpgradePlugin</name>
+            <set-method>addUpgradePlugin</set-method>
+            <type>org.exoplatform.addons.gamification.upgrade.RuleNameUpgradePlugin</type>
+            <description>Fix rule Title</description>
+            <init-params>
+                <value-param>
+                    <name>product.group.id</name>
+                    <description>The groupId of the product</description>
+                    <value>org.exoplatform.addons.gamification</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.execution.order</name>
+                    <description>The plugin execution order</description>
+                    <value>2</value>
+                </value-param>
+                <value-param>
+                    <name>plugin.upgrade.execute.once</name>
+                    <description>Execute this upgrade pluginonly once</description>
+                    <value>true</value>
+                </value-param>
+            </init-params>
+        </component-plugin>
+    </external-component-plugins>
+</configuration>

--- a/services/src/main/java/org/exoplatform/addons/gamification/upgrade/RuleNameUpgradePlugin.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/upgrade/RuleNameUpgradePlugin.java
@@ -33,7 +33,7 @@ public class RuleNameUpgradePlugin extends UpgradeProductPlugin {
              .filter(ruleDTO -> ruleDTO.getTitle().startsWith("GAMIFICATION_DEFAULT_DATA_PREFIX"))
              .forEach(ruleDTO -> {
                  String ruleTitle= ruleDTO.getTitle();
-                 ruleTitle=ruleTitle.replace("GAMIFICATION_DEFAULT_DATA_PREFIX_",
+                 ruleTitle=ruleTitle.replace("GAMIFICATION_DEFAULT_DATA_PREFIX",
                                              GamificationConstant.GAMIFICATION_DEFAULT_DATA_PREFIX);
                  ruleDTO.setTitle(ruleTitle);
                  try {

--- a/services/src/main/java/org/exoplatform/addons/gamification/upgrade/RuleNameUpgradePlugin.java
+++ b/services/src/main/java/org/exoplatform/addons/gamification/upgrade/RuleNameUpgradePlugin.java
@@ -1,0 +1,48 @@
+package org.exoplatform.addons.gamification.upgrade;
+
+
+import org.exoplatform.addons.gamification.GamificationConstant;
+import org.exoplatform.addons.gamification.service.configuration.RuleService;
+import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
+import org.exoplatform.addons.gamification.service.setting.rule.impl.RuleRegistryImpl;
+import org.exoplatform.commons.api.settings.SettingService;
+import org.exoplatform.commons.upgrade.UpgradeProductPlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.services.log.ExoLogger;
+import org.exoplatform.services.log.Log;
+
+import java.util.List;
+
+public class RuleNameUpgradePlugin extends UpgradeProductPlugin {
+    private              RuleService ruleService;
+    private static final Log         LOG = ExoLogger.getLogger(RuleNameUpgradePlugin.class);
+
+    public RuleNameUpgradePlugin(SettingService settingService, InitParams initParams, RuleService ruleService) {
+        
+        super(settingService, initParams);
+        this.ruleService=ruleService;
+        
+    }
+    
+    @Override
+    public void processUpgrade(String oldVersion, String newVersion) {
+
+        List<RuleDTO> rules = ruleService.getAllRules();
+        
+        rules.stream()
+             .filter(ruleDTO -> ruleDTO.getTitle().startsWith("GAMIFICATION_DEFAULT_DATA_PREFIX"))
+             .forEach(ruleDTO -> {
+                 String ruleTitle= ruleDTO.getTitle();
+                 ruleTitle=ruleTitle.replace("GAMIFICATION_DEFAULT_DATA_PREFIX_",
+                                             GamificationConstant.GAMIFICATION_DEFAULT_DATA_PREFIX);
+                 ruleDTO.setTitle(ruleTitle);
+                 try {
+                     ruleService.updateRule(ruleDTO);
+                 } catch (Exception e) {
+                     LOG.error("Unable to update Rule "+ruleDTO.getTitle());
+                 }
+             });
+        
+        
+    }
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/service/upgrade/RuleNameUpgradePluginTest.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/service/upgrade/RuleNameUpgradePluginTest.java
@@ -1,0 +1,25 @@
+package org.exoplatform.addons.gamification.service.upgrade;
+
+import org.exoplatform.addons.gamification.service.dto.configuration.RuleDTO;
+import org.exoplatform.addons.gamification.test.AbstractServiceTest;
+import org.exoplatform.addons.gamification.upgrade.RuleNameUpgradePlugin;
+import org.exoplatform.container.xml.InitParams;
+import org.junit.Test;
+
+public class RuleNameUpgradePluginTest extends AbstractServiceTest {
+  @Test
+  public void testUpgradeRuleName() {
+    newRule("GAMIFICATION_DEFAULT_DATA_PREFIX","domain");
+    
+    RuleDTO rule = ruleService.findRuleByTitle("GAMIFICATION_DEFAULT_DATA_PREFIX_domain");
+    assertTrue(rule.getTitle().startsWith("GAMIFICATION_DEFAULT_DATA_PREFIX"));
+    
+    Long id= rule.getId();
+  
+    RuleNameUpgradePlugin upgradePlugin = new RuleNameUpgradePlugin(null,new InitParams(),ruleService);
+    upgradePlugin.processUpgrade("0","0");
+    RuleDTO ruleAfter = ruleService.findRuleById(id);
+    assertFalse(ruleAfter.getTitle().startsWith("GAMIFICATION_DEFAULT_DATA_PREFIX"));
+  
+  }
+}

--- a/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
+++ b/services/src/test/java/org/exoplatform/addons/gamification/test/InitContainerTestSuite.java
@@ -4,6 +4,7 @@ import org.exoplatform.addons.gamification.service.GamificationServiceTest;
 import org.exoplatform.addons.gamification.service.configuration.BadgeServiceTest;
 import org.exoplatform.addons.gamification.service.configuration.DomainServiceTest;
 import org.exoplatform.addons.gamification.service.configuration.RuleServiceTest;
+import org.exoplatform.addons.gamification.service.upgrade.RuleNameUpgradePluginTest;
 import org.exoplatform.addons.gamification.storage.dao.BadgeDAOTest;
 import org.exoplatform.addons.gamification.storage.dao.RuleDAOTest;
 import org.exoplatform.addons.gamification.test.rest.TestManageBadgesEndpoint;
@@ -26,6 +27,7 @@ import org.junit.runners.Suite.SuiteClasses;
         RuleDAOTest.class,
         TestManageDomainsEndpoint.class,
         TestManageBadgesEndpoint.class,
+        RuleNameUpgradePluginTest.class
 })
 @ConfigTestCase(AbstractServiceTest.class)
 public class InitContainerTestSuite extends BaseExoContainerTestSuite {


### PR DESCRIPTION
PLF-8656 : Upgrade from 5.3.0->5.3.1-RC01 generate error logs at startup
    
    In PLF-5.3.0, with gamification-1.2.0, rules where created with a name which is not the good one.
    To address this issue, I created an upgrade plugin, which check all rules names, and modify it if necessary
    
    This plugin must executed in all version, once.
